### PR TITLE
Avoid crashing on empty JSON data

### DIFF
--- a/lib/action_cable_client.rb
+++ b/lib/action_cable_client.rb
@@ -162,6 +162,7 @@ class ActionCableClient
   #        with the identifier '_ping' are skipped
   def handle_received_message(message, skip_pings = true)
     string = message.data
+    return if string.empty?
     json = JSON.parse(string)
 
     if is_ping?(json)

--- a/spec/unit/action_cable_client_spec.rb
+++ b/spec/unit/action_cable_client_spec.rb
@@ -38,6 +38,17 @@ describe ActionCableClient::Message do
           end.to yield_with_args(hash)
         end
       end
+
+      context 'empty messages are ignored' do
+        let(:message) { OpenStruct.new(data: '') }
+
+        it 'dont yield' do
+          expect do |b|
+            @client._subscribed = true
+            @client.send(:handle_received_message, message, false, &b)
+          end.not_to yield_with_args
+        end
+      end
     end
 
     context '#perform' do


### PR DESCRIPTION
I encounter the following error on a regular basis:
```
/Users/mike/.rubies/ruby-2.3.1/lib/ruby/2.3.0/json/common.rb:156:in `initialize': A JSON text must at least contain two octets! (JSON::ParserError)
	from /Users/mike/.rubies/ruby-2.3.1/lib/ruby/2.3.0/json/common.rb:156:in `new'
	from /Users/mike/.rubies/ruby-2.3.1/lib/ruby/2.3.0/json/common.rb:156:in `parse'
	from /Users/mike/.gem/ruby/2.3.1/gems/action_cable_client-1.3.3/lib/action_cable_client.rb:166:in `handle_received_message'
	from /Users/mike/.gem/ruby/2.3.1/gems/action_cable_client-1.3.3/lib/action_cable_client.rb:74:in `block in received'
	from /Users/mike/.gem/ruby/2.3.1/gems/em-websocket-client-0.1.2/lib/em-websocket-client.rb:43:in `receive_data'
	from /Users/mike/.gem/ruby/2.3.1/gems/eventmachine-1.2.0.1/lib/eventmachine.rb:194:in `run_machine'
	from /Users/mike/.gem/ruby/2.3.1/gems/eventmachine-1.2.0.1/lib/eventmachine.rb:194:in `run'
```

This PR fixes the issue: exit processing on empty payload.