### PR TITLE
More interop with Rails

### DIFF
--- a/lib/action_cable_client.rb
+++ b/lib/action_cable_client.rb
@@ -39,12 +39,16 @@ class ActionCableClient
     @_subscribed = false
 
     @_message_factory = MessageFactory.new(channel)
+
+    origin = URI.parse(_uri)
+    origin.scheme = origin.scheme == "ws" ? "http" : "https"
+
     # NOTE:
     #   EventMachine::WebSocketClient
     #      https://github.com/mwylde/em-websocket-client/blob/master/lib/em-websocket-client.rb
     #   is a subclass of
     #      https://github.com/eventmachine/eventmachine/blob/master/lib/em/connection.rb
-    @_websocket_client = EventMachine::WebSocketClient.connect(_uri)
+    @_websocket_client = EventMachine::WebSocketClient.connect(_uri, origin: origin.to_s)
   end
 
   # @param [String] action - how the message is being sent

--- a/lib/action_cable_client.rb
+++ b/lib/action_cable_client.rb
@@ -32,7 +32,6 @@ class ActionCableClient
   # @param [Boolean] queued_send - optionally send messages after a ping
   #                                is received, rather than instantly
   def initialize(uri, channel = '', queued_send = false)
-    @_channel_name = channel
     @_uri = uri
     @_queued_send = queued_send
     @message_queue = []

--- a/lib/action_cable_client/message_factory.rb
+++ b/lib/action_cable_client/message_factory.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 class ActionCableClient
   class MessageFactory
-    attr_reader :_channel
+    attr_reader :identifier
 
-    # @param [String] channel - the name of the subscribed channel
+    # @param [String or Hash] channel - the name of the subscribed channel, or
+    #   a hash that includes the :channel key and any other params to send.
     def initialize(channel)
-      @_channel = channel
+      @identifier =
+        case channel
+        when String then { channel: channel }
+        when Hash then channel
+        end
     end
 
     # @param [String] command - the type of message that this is
@@ -21,13 +26,6 @@ class ActionCableClient
     # @return [Hash] The data that will be included in the message
     def build_data(action, message)
       message.merge(action: action) if message.is_a?(Hash)
-    end
-
-    # the ending result should look like
-    # "{"channel":"RoomChannel"}" but that's up to
-    # the Mesage to format it
-    def identifier
-      { channel: _channel }
     end
   end
 end


### PR DESCRIPTION
This PR improves interop with Rails by:

* Sending an "Origin" header to work with typical config.action_cable.allowed_request_origins
* Passing params with a subscription

Note that the "Origin" feature relies on the master version of em-websocket-client.  See issue mwylde/em-websocket-client#8.  So don't merge it yet, but if the requested version of em-websocket-client becomes available, would these changes appeal to you?