### PR TITLE
Add pinged hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,13 @@ client = ActionCableClient.new(uri, 'RoomChannel', false)
 client.connect!(headers = {})
 ```
 
-this way if you also enable ping receiving via
 ```ruby
-client.received(false) do |json|
-  # now pings will be here as well, because skip_pings is set to false
+client.pinged do |_data|
+  # you could track the time since you last received a ping, if you haven't
+  # received one in a while, it could be that your client is disconnected.
 end
 ```
 
-you could track the time since you last received a ping, if you haven't received one in a while, it could be that your client is disconnected.
 
 To reconnect,
 
@@ -119,8 +118,6 @@ There really isn't that much to this gem. :-)
 
 4. Notes:
   - Every message sent to the server has a `command` and `identifier` key.
-  - Ping messages from the action cable server look like:
-    - `{ "type" => "ping", "message" =>  1461845503 }`
   - The channel value must match the `name` of the channel class on the ActionCable server.
   - `identifier` and `data` are redundantly jsonified. So, for example (in ruby):
 ```ruby

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The available hooks to tie in to are:
  - `subscribed {}`
  - `errored { |msg| }`
  - `received { |msg }`
+ - `pinged { |msg| }`
 
 
 #### Connecting on initialization is also configurable.

--- a/lib/action_cable_client.rb
+++ b/lib/action_cable_client.rb
@@ -23,7 +23,7 @@ class ActionCableClient
   attr_reader :_message_factory
   # The queue should store entries in the format:
   # [ action, data ]
-  attr_accessor :message_queue, :_subscribed, :_subscribed_callaback
+  attr_accessor :message_queue, :_subscribed, :_subscribed_callaback, :_pinged_callback
 
   def_delegator :_websocket_client, :onerror, :errored
   def_delegator :_websocket_client, :send, :send_msg
@@ -138,6 +138,10 @@ class ActionCableClient
     end
   end
 
+  def pinged(&block)
+    self._pinged_callback = block
+  end
+
   private
 
   # @param [String] message - the websockt message object
@@ -148,6 +152,7 @@ class ActionCableClient
     json = JSON.parse(message)
 
     if is_ping?(json)
+      _pinged_callback&.call(json)
       yield(json) unless skip_pings
     elsif !subscribed?
       check_for_subscribe_confirmation(json)

--- a/lib/action_cable_client.rb
+++ b/lib/action_cable_client.rb
@@ -70,18 +70,15 @@ class ActionCableClient
   # callback for received messages as well as
   # what triggers depleting the message queue
   #
-  # @param [Boolean] skip_pings - by default, messages
-  #        with the identifier '_ping' are skipped
-  #
   # @example
   #   client = ActionCableClient.new(uri, 'RoomChannel')
   #   client.received do |message|
   #     # the received message will be JSON
   #     puts message
   #   end
-  def received(skip_pings = true)
+  def received
     _websocket_client.onmessage do |message, _type|
-      handle_received_message(message, skip_pings) do |json|
+      handle_received_message(message) do |json|
         yield(json)
       end
     end
@@ -145,15 +142,12 @@ class ActionCableClient
   private
 
   # @param [String] message - the websockt message object
-  # @param [Boolean] skip_pings - by default, messages
-  #        with the identifier '_ping' are skipped
-  def handle_received_message(message, skip_pings = true)
+  def handle_received_message(message)
     return if message.empty?
     json = JSON.parse(message)
 
     if is_ping?(json)
       _pinged_callback&.call(json)
-      yield(json) unless skip_pings
     elsif !subscribed?
       check_for_subscribe_confirmation(json)
     else

--- a/spec/unit/action_cable_client_spec.rb
+++ b/spec/unit/action_cable_client_spec.rb
@@ -17,14 +17,8 @@ describe ActionCableClient::Message do
         let(:message) { hash.to_json }
         it 'nothing is yielded' do
           expect do |b|
-            @client.send(:handle_received_message, message, true, &b)
+            @client.send(:handle_received_message, message, &b)
           end.to_not yield_with_args
-        end
-
-        it 'yields the ping' do
-          expect do |b|
-            @client.send(:handle_received_message, message, false, &b)
-          end.to yield_with_args(hash)
         end
 
         it 'calls _pinged_callback' do
@@ -47,7 +41,7 @@ describe ActionCableClient::Message do
         it 'yields whatever' do
           expect do |b|
             @client._subscribed = true
-            @client.send(:handle_received_message, message, false, &b)
+            @client.send(:handle_received_message, message, &b)
           end.to yield_with_args(hash)
         end
 
@@ -64,7 +58,7 @@ describe ActionCableClient::Message do
         it 'dont yield' do
           expect do |b|
             @client._subscribed = true
-            @client.send(:handle_received_message, message, false, &b)
+            @client.send(:handle_received_message, message, &b)
           end.not_to yield_with_args
         end
       end

--- a/spec/unit/action_cable_client_spec.rb
+++ b/spec/unit/action_cable_client_spec.rb
@@ -26,6 +26,18 @@ describe ActionCableClient::Message do
             @client.send(:handle_received_message, message, false, &b)
           end.to yield_with_args(hash)
         end
+
+        it 'calls _pinged_callback' do
+          result = nil
+
+          @client.pinged do |data|
+            result = data
+          end
+
+          @client.send(:handle_received_message, message)
+
+          expect(result).to eq(hash)
+        end
       end
 
       context 'is not a ping' do
@@ -37,6 +49,12 @@ describe ActionCableClient::Message do
             @client._subscribed = true
             @client.send(:handle_received_message, message, false, &b)
           end.to yield_with_args(hash)
+        end
+
+        it 'does not call _pinged_callback' do
+          expect(@client).to_not receive(:_pinged_callback)
+
+          @client.send(:handle_received_message, message)
         end
       end
 
@@ -117,6 +135,16 @@ describe ActionCableClient::Message do
 
     context '#disconnected' do
       it 'sets subscribed to false' do
+      end
+    end
+
+    context '#pinged' do
+      it 'sets the callback' do
+        expect(@client._pinged_callback).to eq(nil)
+
+        @client.pinged {}
+
+        expect(@client._pinged_callback).to_not eq(nil)
       end
     end
 


### PR DESCRIPTION
Hello,

I find a little difficult and/or inconsistent to catch ActionCable `pings` within `received` hook.

I would get rid of all the `skip_pings` code too (I didn't in order to maintain backward compatibility).

Have a look please, and let me know.

Thanks!