### PR TITLE
Add handler for rejections from ActionCable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The available hooks to tie in to are:
  - `disconnected {}`
  - `connected {}`
  - `subscribed {}`
+ - `rejected {}`
  - `errored { |msg| }`
  - `received { |msg }`
  - `pinged { |msg| }`

--- a/lib/action_cable_client/message.rb
+++ b/lib/action_cable_client/message.rb
@@ -9,6 +9,7 @@ class ActionCableClient
     # TODO: find a better place for this constant
     TYPE_KEY = 'type'
     TYPE_CONFIRM_SUBSCRIPTION = 'confirm_subscription'
+    TYPE_REJECT_SUBSCRIPTION = 'reject_subscription'
 
     attr_reader :_command, :_identifier, :_data
 

--- a/spec/unit/action_cable_client_spec.rb
+++ b/spec/unit/action_cable_client_spec.rb
@@ -89,6 +89,23 @@ describe ActionCableClient do
         end
       end
 
+      context 'is a rejection' do
+        let(:hash) { { 'type' => 'reject_subscription' } }
+        let(:message) { hash.to_json }
+
+        it 'calls _rejected_callback' do
+          result = nil
+
+          @client.rejected do |data|
+            result = data
+          end
+
+          @client.send(:handle_received_message, message)
+
+          expect(result).to eq(hash)
+        end
+      end
+
       context 'empty messages are ignored' do
         let(:message) { '' }
 


### PR DESCRIPTION
I recently implemented a rejection protocol in our ActionCable setup following the example here https://api.rubyonrails.org/classes/ActionCable/Channel/Base.html#class-ActionCable::Channel::Base-label-Rejecting+subscription+requests

Essentially we're allowing people to gain a connection to the server, but we want to reject their subscriptions if they are not authorized to view a certain channel. I noticed that the gem didn't support this.

I wasn't sure if anything more was needed in the README?

Tests are still all 💚 
```
rspec
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 18484

ActionCableClient
  with empty WebSocketClient
    #connected
      sets the callback
    #disconnected
      sets the callback
      sets subscribed to false
    #handle_received_message
      is not a ping
        yields whatever
        does not call _pinged_callback
      is a welcome
        subscribes
        calls _connected_callback
      is a rejection
        calls _rejected_callback
      is a ping
        nothing is yielded
        calls _pinged_callback
      empty messages are ignored
        dont yield
    #subscribed
      once the callback is set, receiving a subscription confirmation invokes the callback
      sets the callback
    #subscribe
      sends a message
    #reconnect!
      asks EventMachine to reconnect on same host and port
      fires EventMachine::WebSocket::Client #post_init
    #perform
      dispatches the message
      does not add to the queue
    #dispatch_message
      calls sends when subscribed
      does not send if not subscribed
    #pinged
      sets the callback
    #is_ping?
      is a ping
      is not a ping when it is a confirmation
      is not a ping
    #check_for_subscribe_confirmation
      is a subscribtion confirmation

ActionCableClient::MessageFactory
  requires a proper channel name
  initializes with a channel name
  builds the identifier based off the channel name
  #create
    creates a message
  #build_data
    returns a constructed hash, given a message
    returns a constructed hash, given empty message

ActionCableClient::Message
  sets the attributes
  #to_json
    when data is present
      double the identifier and the data if the value would be 0
      double the identifier and the data if the value would be 1
      double the identifier and the data if the value would be #<Object:0x00007fd20ee26868>
      double the identifier and the data if the value would be [nil]
      double the identifier and the data if the value would be "a"
      double the identifier and the data if the value would be {nil=>0}
      double the identifier and the data if the value would be true
      double the identifier and the data if the value would be 2020-01-31 10:32:09 -0800
    when data is not prsent
      does not set :data if the value would be {}
      does not set :data if the value would be "　"
      does not set :data if the value would be "  \n\t  \r "
      does not set :data if the value would be " "
      does not set :data if the value would be "   "
      does not set :data if the value would be []
      does not set :data if the value would be nil
      does not set :data if the value would be ""
      does not set :data if the value would be false

Finished in 0.02507 seconds (files took 0.41653 seconds to load)
49 examples, 0 failures

Randomized with seed 18484

Coverage report generated for RSpec to /Users/jeremy/workspace/jer-k/action_cable_client/coverage. 179 / 184 LOC (97.28%) covered.
```