### PR TITLE
Reconnect through normal websocket setup

### DIFF
--- a/lib/action_cable_client.rb
+++ b/lib/action_cable_client.rb
@@ -24,8 +24,9 @@ class ActionCableClient
   # [ action, data ]
   attr_accessor :message_queue, :_subscribed
   attr_accessor :_subscribed_callback, :_rejected_callback, :_pinged_callback, :_connected_callback, :_disconnected_callback
+  attr_accessor :_received_callback, :_errored_callback, :_headers, :_tls
+  attr_accessor :_connection_id
 
-  def_delegator :_websocket_client, :onerror, :errored
   def_delegator :_websocket_client, :send, :send_msg
 
   # @param [String] uri - e.g.: ws://domain:port
@@ -40,6 +41,9 @@ class ActionCableClient
     @_uri = uri
     @message_queue = []
     @_subscribed = false
+    @_connection_id = 0
+    @_headers = headers
+    @_tls = tls
 
     @_message_factory = MessageFactory.new(params)
 
@@ -47,6 +51,10 @@ class ActionCableClient
   end
 
   def connect!(headers = {}, tls = {})
+    self._headers = headers
+    self._tls = tls
+    self._connection_id += 1
+    connection_id = _connection_id
     # Quick Reference for WebSocket::EM::Client's api
     # - onopen - called after successfully connecting
     # - onclose - called after closing connection
@@ -62,15 +70,21 @@ class ActionCableClient
     @_websocket_client = WebSocket::EventMachine::Client.connect(uri: @_uri, headers: headers, tls: tls)
 
     @_websocket_client.onclose do
-      self._subscribed = false
-      _disconnected_callback&.call
+      if connection_id == _connection_id
+        self._subscribed = false
+        _disconnected_callback&.call
+      end
     end
+
+    attach_received_callback
+    attach_errored_callback
   end
 
   def reconnect!
-    uri = URI(@_uri)
-    EventMachine.reconnect uri.host, uri.port, @_websocket_client
-    @_websocket_client.post_init
+    self._connection_id += 1
+    _websocket_client.close if _websocket_client.respond_to?(:close)
+    self._subscribed = false
+    connect!(_headers, _tls)
   end
 
   # @param [String] action - how the message is being sent
@@ -89,11 +103,13 @@ class ActionCableClient
   #     puts message
   #   end
   def received
-    _websocket_client.onmessage do |message, _type|
-      handle_received_message(message) do |json|
-        yield(json)
-      end
-    end
+    self._received_callback = proc { |json| yield(json) }
+    attach_received_callback
+  end
+
+  def errored
+    self._errored_callback = proc { |error| yield(error) }
+    attach_errored_callback
   end
 
   # callback when the client connects to the server
@@ -163,6 +179,22 @@ class ActionCableClient
   end
 
   private
+
+  def attach_received_callback
+    return unless _received_callback
+
+    connection_id = _connection_id
+    _websocket_client.onmessage do |message, _type|
+      handle_received_message(message, &_received_callback) if connection_id == _connection_id
+    end
+  end
+
+  def attach_errored_callback
+    return unless _errored_callback
+
+    connection_id = _connection_id
+    _websocket_client.onerror { |error| _errored_callback.call(error) if connection_id == _connection_id }
+  end
 
   # @param [String] message - the websockt message object
   def handle_received_message(message)

--- a/spec/unit/action_cable_client_spec.rb
+++ b/spec/unit/action_cable_client_spec.rb
@@ -318,6 +318,25 @@ describe ActionCableClient do
         expect(connected_messages).to eq([])
       end
 
+      it 'ignores the old websocket close callback if close fires it during reconnect' do
+        disconnected_calls = []
+
+        @client._subscribed = true
+        @client.disconnected do
+          disconnected_calls << true
+        end
+
+        allow(websocket_client).to receive(:close) do
+          @websocket_client_onclose_block.call
+        end
+        expect(websocket_client_class).to receive(:connect).and_return(reconnected_websocket_client)
+
+        @client.reconnect!
+
+        expect(disconnected_calls).to eq([])
+        expect(@client._websocket_client).to eq(reconnected_websocket_client)
+      end
+
       it 'reattaches the errored callback to the new websocket' do
         errors = []
 

--- a/spec/unit/action_cable_client_spec.rb
+++ b/spec/unit/action_cable_client_spec.rb
@@ -5,14 +5,17 @@ require 'ostruct'
 
 describe ActionCableClient do
   context 'with empty WebSocketClient' do
+    let!(:websocket_client_class) { class_double(WebSocket::EventMachine::Client).as_stubbed_const }
     let!(:websocket_client) do
-      websocket_client_class = class_double(WebSocket::EventMachine::Client).as_stubbed_const
       websocket_client = instance_double(WebSocket::EventMachine::Client)
 
       allow(websocket_client_class).to receive(:connect).and_return websocket_client
       allow(websocket_client).to receive(:onclose) do |&block|
         @websocket_client_onclose_block = block
       end
+      allow(websocket_client).to receive(:onmessage)
+      allow(websocket_client).to receive(:onerror)
+      allow(websocket_client).to receive(:close)
 
       websocket_client
     end
@@ -238,22 +241,100 @@ describe ActionCableClient do
     end
 
     context '#reconnect!' do
-      before do
-        allow(EventMachine).to receive(:reconnect)
-        allow(websocket_client).to receive(:post_init)
+      let(:reconnected_websocket_client) do
+        client = instance_double(WebSocket::EventMachine::Client)
+        allow(client).to receive(:onclose)
+        allow(client).to receive(:onmessage)
+        allow(client).to receive(:onerror)
+        allow(client).to receive(:close)
+        client
       end
 
-      it 'asks EventMachine to reconnect on same host and port' do
-        expect(EventMachine).to receive(:reconnect).with(host, port, websocket_client)
-        @client.reconnect!
+      it 'closes the old websocket and connects a new one with the same connection options' do
+        headers = { 'Authorization' => 'Bearer token' }
+        tls = { cert_chain_file: 'user.crt' }
+        client = ActionCableClient.new("ws://#{host}:#{port}", 'RoomChannel', true, headers, tls)
+
+        expect(client._websocket_client).to receive(:close)
+        expect(websocket_client_class).to receive(:connect).with(
+          uri: "ws://#{host}:#{port}",
+          headers: headers,
+          tls: tls
+        ).and_return(reconnected_websocket_client)
+
+        client.reconnect!
+
+        expect(client._websocket_client).to eq(reconnected_websocket_client)
+        expect(client.subscribed?).to eq false
       end
 
-      it 'fires EventMachine::WebSocket::Client #post_init' do
-        # NOTE: in some cases, its required. Have a look to
-        # https://github.com/imanel/websocket-eventmachine-client/issues/14
-        # https://github.com/eventmachine/eventmachine/issues/218
-        expect(websocket_client).to receive(:post_init)
+      it 'reattaches the received callback to the new websocket' do
+        received_messages = []
+        connected_messages = []
+
+        @client.received do |message|
+          received_messages << message
+        end
+        @client.connected do |message|
+          connected_messages << message
+        end
+
+        allow(reconnected_websocket_client).to receive(:onmessage) do |&block|
+          @reconnected_onmessage_block = block
+        end
+        expect(websocket_client_class).to receive(:connect).and_return(reconnected_websocket_client)
+
         @client.reconnect!
+
+        message = { 'type' => 'welcome' }
+        @reconnected_onmessage_block.call(message.to_json, nil)
+
+        expect(connected_messages).to eq([message])
+        expect(received_messages).to eq([])
+      end
+
+      it 'ignores stale callbacks from the old websocket after reconnecting' do
+        connected_messages = []
+
+        @client.received {}
+        @client.connected do |message|
+          connected_messages << message
+        end
+
+        allow(websocket_client).to receive(:onmessage) do |&block|
+          @old_onmessage_block = block
+        end
+        @client.received {}
+
+        expect(websocket_client_class).to receive(:connect).and_return(reconnected_websocket_client)
+
+        @client.reconnect!
+
+        @client._subscribed = true
+        @websocket_client_onclose_block.call
+        @old_onmessage_block.call({ 'type' => 'welcome' }.to_json, nil)
+
+        expect(@client.subscribed?).to eq true
+        expect(connected_messages).to eq([])
+      end
+
+      it 'reattaches the errored callback to the new websocket' do
+        errors = []
+
+        @client.errored do |error|
+          errors << error
+        end
+
+        allow(reconnected_websocket_client).to receive(:onerror) do |&block|
+          @reconnected_onerror_block = block
+        end
+        expect(websocket_client_class).to receive(:connect).and_return(reconnected_websocket_client)
+
+        @client.reconnect!
+
+        @reconnected_onerror_block.call('connection failed')
+
+        expect(errors).to eq(['connection failed'])
       end
     end
   end


### PR DESCRIPTION
## Summary
- make reconnect! close the stale websocket and reconnect through connect!
- preserve headers, TLS options, received handlers, and error handlers across reconnects
- guard stale websocket callbacks so old close/message/error events cannot mutate the new connection state

Fixes #33

## Verification
- `bundle exec rspec spec/unit/action_cable_client_spec.rb`
- `bundle exec rspec`
- `bundle exec rubocop`
- `git diff --check origin/master...HEAD`

## Hosted CI
- Run `26799993832`: RuboCop and Ruby 2.3/2.4/2.5/2.6/2.7 test jobs passed
