### PR TITLE
Remove unsupported Ruby head CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
   test:
     name: Test Ruby ${{ matrix.ruby }}
     runs-on: ubuntu-22.04
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
@@ -23,11 +22,6 @@ jobs:
           - '2.5'
           - '2.6'
           - '2.7'
-        experimental:
-          - false
-        include:
-          - ruby: head
-            experimental: true
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Remove the experimental Ruby head CI matrix entry.

Ruby head currently resolves to `ruby 4.1.0dev`, where `eventmachine 1.2.7` fails while building its native extension before the test suite can run. The workflow-level result can still appear successful because of `continue-on-error`, but GitHub still shows the individual Ruby head job as failed on the merged commit.

This keeps CI focused on the stable supported Rubies already in the matrix: 2.3 through 2.7.

## Verification

- `bundle exec rspec`
- `bundle exec rubocop --cache false`
- `git diff --check`
- `review-fix-loop`: no actionable correctness issues
